### PR TITLE
Update Cargo.toml to include repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["rmsthebest"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Peripheral access API for HT32F523x2 microcontrollers"
 documentation = "https://docs.rs/ht32f523x2"
+repository = "https://github.com/rmsthebest/ht32f523x2"
 edition = "2018"
 keywords = ["arm", "cortex-m", "ht32", "svd2rust"]
 license = "GPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,12 @@ authors = ["rmsthebest"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Peripheral access API for HT32F523x2 microcontrollers"
 documentation = "https://docs.rs/ht32f523x2"
-repository = "https://github.com/rmsthebest/ht32f523x2"
 edition = "2018"
 keywords = ["arm", "cortex-m", "ht32", "svd2rust"]
 license = "GPL-3.0"
 name = "ht32f523x2"
 readme = "README.md"
+repository = "https://github.com/rmsthebest/ht32f523x2"
 version = "0.2.0"
 
 [dependencies]


### PR DESCRIPTION
This will also add a link to the repo on the crates.io page.